### PR TITLE
Cluster aware client lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This is an ongoing learning project, evolving organically as new ideas and use c
 - Raft-based consensus and log replication
 - Cluster initialization and dynamic membership via CLI
 - Hierarchical key-value store with path-like namespaces (e.g. `/app/config/timeout`)
-- Watch/subscribe API: clients can receive real-time updates on key changes
-- Rust client library (gRPC-based)
+- Watch/subscribe API:
+    - `WatchConfig`: Clients can receive real-time updates on key changes.
+    - `WatchCluster`: Clients can subscribe to and receive updates about the cluster's voting members (additions and removals) and the current leader.
+- Rust client library (gRPC-based) enabling interaction with the Confer cluster, including subscribing to configuration and cluster updates.
 
 ---
 

--- a/client/proto/confer.proto
+++ b/client/proto/confer.proto
@@ -21,15 +21,12 @@ service ConferService {
 
   // WatchConfig watches for changes to the configuration value at the given path.
   // The server sends a stream of WatchUpdate messages to the client.
-  rpc WatchConfig(ConfigPath) returns (stream WatchUpdate) {}
+  rpc WatchConfig(ConfigPath) returns (stream ConfigUpdate) {}
 
   // UnwatchConfig stops watching the configuration at the given path.
   rpc UnwatchConfig(ConfigPath) returns (Empty) {}
 
-  // WatchLeader watches for changes in the Raft leader.  The server sends a
-  // WatchUpdate message whenever the leader changes.
-  rpc WatchLeader(Empty) returns (stream WatchUpdate) {}
-
+  rpc WatchCluster(Empty) returns (stream ClusterUpdate);
 
   // ------- Cluster operations ------------
 
@@ -142,16 +139,19 @@ message NodeIdSet {
 }
 
 // WatchUpdate is the message sent by the server to clients watching a configuration.
-message WatchUpdate {
-  oneof kind {
-    bytes updated_value = 1;           // The updated value of the configuration.
-    LeaderInfo leader_changed = 2;     // Indicates a change in Raft leadership.
-    Empty removed = 3; // Indicates the configuration was removed.
+message ConfigUpdate {
+  oneof update_type {
+    bytes updated_value = 1;
+    Empty removed = 2;
   }
+  string path = 3;
 }
 
-// LeaderInfo contains information about the Raft leader.
-message LeaderInfo {
-  string address = 1; // The address of the leader.
+message ClusterUpdate {
+  oneof update_type {
+    Node leader_changed = 1;
+    Node member_added = 2;
+    uint64 member_removed = 3;
+  }
 }
 

--- a/confer-client-example/src/main.rs
+++ b/confer-client-example/src/main.rs
@@ -1,151 +1,90 @@
 use confer_client::*;
+//use confer_client::error::ClientError;
 use std::error::Error;
+use std::sync::Arc;
 use tokio::time::{sleep, Duration};
-use tokio::task::JoinHandle;
-use confer_client::confer::v1::watch_update::Kind;
-//use tonic::transport::ClientTlsConfig;
+use confer_client::confer::v1::config_update::UpdateType as ConfigUpdateKind;
+use confer_client::confer::v1::cluster_update::UpdateType as ClusterUpdateKind;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // --- Configuration ---
-    let server_address_1 = "http://127.0.0.1:10001".to_string(); // Leader
-    let server_address_2 = "http://127.0.0.1:10002".to_string(); // Follower
-    let key = "my-watched-key".to_string();
-    let initial_value = "initial-value".as_bytes().to_vec();
-    let tls_config = None; // Or Some(ClientTlsConfig::new()) if you have TLS setup
+    let server_address = "http://127.0.0.1:10001".to_string();
+    let config_key = "my-watched-config".to_string();
+    let tls_config = None;
 
-    // --- Connect to Confer servers ---
-    println!("Connecting to Confer servers...");
-    let mut leader_client = ConferClient::new(server_address_1.clone(), tls_config.clone()).await?;
-    let mut follower_client = ConferClient::new(server_address_2.clone(), tls_config.clone()).await?;
+    // --- Create a single ConferClient instance ---
+    println!("Creating a single ConferClient instance...");
+    let client = Arc::new(ConferClient::new(server_address.clone(), tls_config.clone()).await?);
+    let client_clone = Arc::clone(&client);
 
-    // --- Basic Data Manipulation (set, get, delete) ---
-    println!("\n\n--- Basic Data Manipulation ---");
-    println!("\nSetting initial value for key: {} on leader ({}): value: {:?}", key, server_address_1, initial_value);
-    leader_client.set(key.clone(), initial_value.clone()).await?;
-
-    println!("\nGetting value for key: {} on follower ({}):", key, server_address_2);
-    let retrieved_value_follower = follower_client.get(key.clone()).await?;
-    println!("Retrieved value on follower: {:?}", retrieved_value_follower);
-
-    println!("\nGetting value for key: {} on leader ({}):", key, server_address_1);
-    let retrieved_value_leader = leader_client.get(key.clone()).await?;
-    println!("Retrieved value on leader: {:?}", retrieved_value_leader);
-
-    let new_value_1 = "new-value-1".as_bytes().to_vec();
-    println!("\nUpdating value for key: {} on follower ({}): value: {:?}", key, server_address_2, new_value_1);
-    follower_client.set(key.clone(), new_value_1.clone()).await?;
-    sleep(Duration::from_secs(1)).await;
-
-    println!("\nGetting value for key: {} on leader ({}) after update from follower:", key, server_address_1);
-    let retrieved_value_leader_2 = leader_client.get(key.clone()).await?;
-    println!("Retrieved value on leader after update from follower: {:?}", retrieved_value_leader_2);
-
-    println!("\nDeleting key: {} on leader ({})", key, server_address_1);
-    leader_client.remove(key.clone()).await?;
-
-    println!("\nGetting value for key: {} on follower ({}) after deletion:", key, server_address_2);
-    let result_follower = follower_client.get(key.clone()).await;
-    match result_follower {
-        Ok(_) => println!("--------- Error: Value was not deleted! --------------"),
-        Err(_) => println!("Received Error. Expected Behaviour."),
-    }
-    println!("\nGetting value for key: {} on leader ({}) after deletion:", key, server_address_1);
-    let result_leader = leader_client.get(key.clone()).await;
-    match result_leader {
-        Ok(_) => println!("--------- Error: Value was not deleted! --------------"),
-        Err(_) => println!("Received Error. Expected Behaviour."),
-    }
-
-    // --- Watcher Demonstration (Leader Node) ---
-    println!("\n\n--- Watcher Demonstration (Leader Node) ---");
-    println!("\nSetting up watcher for key: {} on leader ({})", key, server_address_1);
-
-    // Use a channel to communicate between the watcher and the main thread.
-    let (tx, mut rx) = tokio::sync::mpsc::channel(10); // Increased capacity
-
-    let watch_handle: JoinHandle<()> = tokio::spawn({
-        let mut leader_client_clone = ConferClient::new(server_address_1.clone(), tls_config.clone()).await.unwrap(); //clone
-        let key_clone = key.clone();
-        async move {
-            let result = leader_client_clone.watch_config_with_callback(key_clone, move |update_result| {
-                let tx_clone = tx.clone(); // Clone the sender to use in the closure
-                tokio::spawn(async move { //spawn
-                    match update_result {
-                        Ok(update) => {
-                            println!("\nLEADER WATCHER: Received update:");
-                            if let Some(kind) = update.kind {
-                                match kind {
-                                    Kind::UpdatedValue(value) => {
-                                        println!("  Kind: UpdatedValue");
-                                        println!("  Value: {:?}", value);
-                                        if let Ok(s) = String::from_utf8(value.clone()) {
-                                            println!("  Value as string: {}", s);
-                                            tx_clone.send(format!("Updated: {}", s)).await.unwrap(); //send
-                                        }
-                                    }
-                                    Kind::LeaderChanged(leader_info) => {
-                                        println!("  Kind: LeaderChanged");
-                                        println!("  Leader Address: {}", leader_info.address);
-                                         tx_clone.send(format!("LeaderChanged: {}", leader_info.address)).await.unwrap();
-                                    }
-                                    Kind::Removed(_) => {
-                                        println!("  Kind: Removed");
-                                        tx_clone.send("Removed".to_string()).await.unwrap();
-                                    }
-                                }
-                            } else {
-                                println!("  Kind: None");
-                                tx_clone.send("Kind: None".to_string()).await.unwrap();
-                            }
+    // --- Watch Config Updates ---
+    println!("\n--- Watching Config Updates ---");
+    let config_key_clone = config_key.clone();
+    tokio::spawn(async move {
+        let result = client_clone.watch_config_with_callback(config_key_clone, move |update_result| {
+            match update_result {
+                Ok(update) => {
+                    println!("CONFIG WATCHER: Received update for path: {:?}", update.path);
+                    match update.update_type {
+                        Some(ConfigUpdateKind::UpdatedValue(value)) => {
+                            println!("  Kind: UpdatedValue, Value: {:?}", value);
                         }
-                        Err(e) => {
-                            eprintln!("LEADER WATCHER: Error in watcher: {}", e);
-                            tx_clone.send(format!("Error: {}", e)).await.unwrap();
+                        Some(ConfigUpdateKind::Removed(_)) => {
+                            println!("  Kind: Removed");
                         }
+                        None => println!("  Kind: None"),
                     }
-                });
-            }).await;
-            if let Err(e) = result{
-                 eprintln!("LEADER WATCHER: Error setting up the watcher: {}", e);
+                }
+                Err(e) => eprintln!("CONFIG WATCHER Error: {}", e),
             }
+        }).await;
+        if let Err(e) = result {
+            eprintln!("Error setting up config watcher: {}", e);
         }
+        println!("CONFIG WATCHER STARTED.");
     });
 
-    // Give the watcher some time to start.
-    sleep(Duration::from_secs(1)).await;
-
-    let new_value_2 = "new-value-2".as_bytes().to_vec();
-    println!("\nSetting new value for key: {} on leader ({}): value: {:?}", key, server_address_1, new_value_2);
-    leader_client.set(key.clone(), new_value_2.clone()).await?;
+    // Simulate config changes using the original client
+    println!("\nSimulating config changes...");
+    client.set(config_key.clone(), "initial-value".as_bytes().to_vec()).await?;
+    sleep(Duration::from_secs(2)).await;
+    client.set(config_key.clone(), "updated-value-1".as_bytes().to_vec()).await?;
+    sleep(Duration::from_secs(2)).await;
+    client.remove(config_key.clone()).await?;
     sleep(Duration::from_secs(2)).await;
 
-    if let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
-        println!("Main Received from watcher: {}", msg.unwrap());
-    }
+    // --- Watch Cluster Updates ---
+    println!("\n--- Watching Cluster Updates ---");
+    tokio::spawn(async move {
+        let result = client.watch_cluster(move |update_result| {
+            match update_result {
+                Ok(update) => {
+                    println!("CLUSTER WATCHER: Received update:");
+                    match update.update_type {
+                        Some(ClusterUpdateKind::LeaderChanged(node)) => {
+                            println!("  Kind: LeaderChanged, Leader: {:?}", node);
+                        }
+                        Some(ClusterUpdateKind::MemberAdded(node)) => {
+                            println!("  Kind: MemberAdded, Member: {:?}", node);
+                        }
+                        Some(ClusterUpdateKind::MemberRemoved(member_id)) => {
+                            println!("  Kind: MemberRemoved, ID: {}", member_id);
+                        }
+                        None => println!("  Kind: None"),
+                    }
+                }
+                Err(e) => eprintln!("CLUSTER WATCHER Error: {}", e),
+            }
+        });
+        if let Err(e) = result.await {
+            eprintln!("Error setting up cluster watcher: {}", e);
+        }
+        println!("CLUSTER WATCHER STARTED.");
+    });
 
-    let new_value_3 = "new-value-3".as_bytes().to_vec();
-    println!("\nSetting another new value for key: {} on leader ({}): value: {:?}", key, server_address_1, new_value_3);
-    leader_client.set(key.clone(), new_value_3.clone()).await?;
-    sleep(Duration::from_secs(2)).await;
-     if let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
-        println!("Main Received from watcher: {}", msg.unwrap());
-    }
+    // Simulate (potential) cluster changes - this will depend on your server implementation
+    sleep(Duration::from_secs(15)).await;
 
-    // --- Delete the configuration from the leader ---
-    println!("\n\nLEADER: Deleting key: {}", key);
-    leader_client.remove(key.clone()).await?;
-    sleep(Duration::from_secs(2)).await;
-     if let Ok(msg) = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
-        println!("Main Received from watcher: {}", msg.unwrap());
-    }
-
-     // --- Cancel watchers and cleanup ---
-    println!("\n\n--- Cancelling watchers and exiting ---");
-    leader_client.cancel_watchers().await;
-    follower_client.cancel_watchers().await;
-    // Optionally await the handles
-    watch_handle.await.unwrap();
-
+    println!("\nExiting.");
     Ok(())
 }

--- a/proto/confer.proto
+++ b/proto/confer.proto
@@ -21,15 +21,12 @@ service ConferService {
 
   // WatchConfig watches for changes to the configuration value at the given path.
   // The server sends a stream of WatchUpdate messages to the client.
-  rpc WatchConfig(ConfigPath) returns (stream WatchUpdate) {}
+  rpc WatchConfig(ConfigPath) returns (stream ConfigUpdate) {}
 
   // UnwatchConfig stops watching the configuration at the given path.
   rpc UnwatchConfig(ConfigPath) returns (Empty) {}
 
-  // WatchLeader watches for changes in the Raft leader.  The server sends a
-  // WatchUpdate message whenever the leader changes.
-  rpc WatchLeader(Empty) returns (stream WatchUpdate) {}
-
+  rpc WatchCluster(Empty) returns (stream ClusterUpdate);
 
   // ------- Cluster operations ------------
 
@@ -142,16 +139,19 @@ message NodeIdSet {
 }
 
 // WatchUpdate is the message sent by the server to clients watching a configuration.
-message WatchUpdate {
-  oneof kind {
-    bytes updated_value = 1;           // The updated value of the configuration.
-    LeaderInfo leader_changed = 2;     // Indicates a change in Raft leadership.
-    Empty removed = 3; // Indicates the configuration was removed.
+message ConfigUpdate {
+  oneof update_type {
+    bytes updated_value = 1;
+    Empty removed = 2;
   }
+  string path = 3;
 }
 
-// LeaderInfo contains information about the Raft leader.
-message LeaderInfo {
-  string address = 1; // The address of the leader.
+message ClusterUpdate {
+  oneof update_type {
+    Node leader_changed = 1;
+    Node member_added = 2;
+    uint64 member_removed = 3;
+  }
 }
 


### PR DESCRIPTION
The client is now aware of the cluster members via cluster watcher. The client (lib) is notified whenever a node becomes a full member (not a learner) or when  a member leaves the cluster.   The client is also notified of leader changes so that write can be sent to the leader without  a forward. 

Note: Client lib will not reconnect or re-subscribe after a node failure. That feature would be handled in a separate PR. 